### PR TITLE
Add Laravel 12 support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,16 +17,16 @@
     ],
     "require": {
         "php": "^8.1",
-        "illuminate/contracts": "^9.0|^10.0|^11.0",
+        "illuminate/contracts": "^9.0|^10.0|^11.0|^12.0",
         "jonaspardon/mermaid-php": "^1.0.1",
-        "nikic/php-parser": "^4.13",
+        "nikic/php-parser": "^5.0",
         "spatie/laravel-package-tools": "^1.9.2"
     },
     "require-dev": {
         "friendsofphp/php-cs-fixer": "^3.8",
         "larastan/larastan": "^2.0",
         "nunomaduro/collision": "^6.0",
-        "orchestra/testbench": "^7.0",
+        "orchestra/testbench": "^7.0|^8.0|^9.0|^10.0",
         "pestphp/pest": "^1.21",
         "pestphp/pest-plugin-laravel": "^1.1",
         "phpstan/extension-installer": "^1.1",


### PR DESCRIPTION
## Summary
- expand `illuminate/contracts` constraint to include v12
- update `nikic/php-parser` to ^5
- allow newer `orchestra/testbench` versions

## Testing
- `git status --short`